### PR TITLE
Replace Tabler Icons repo

### DIFF
--- a/collections.yml
+++ b/collections.yml
@@ -1755,7 +1755,7 @@ packages:
       -
         name: secondnetwork
     latest_version: v3.4.0
-    downloads: 3 912
+    downloads: 3912
     stars: 7
     listed_on_blade_icon_readme: 1
     original_package:

--- a/collections.yml
+++ b/collections.yml
@@ -1749,44 +1749,92 @@ packages:
       - 1.6.2
       - 1.7.0
   -
-    package: ryangjchandler/blade-tabler-icons
+    package: secondnetwork/blade-tabler-icons
     name: 'Blade Tabler Icons'
     maintainers:
       -
-        name: ryangjchandler
-        avatar_url: 'https://www.gravatar.com/avatar/fd5f60c5d11adc7f0dae46e3b8a1d9e6?d=identicon'
-    latest_version: v1.1.0
-    downloads: 188771
-    stars: 64
+        name: secondnetwork
+    latest_version: v3.4.0
+    downloads: 3 912
+    stars: 7
     listed_on_blade_icon_readme: 1
     original_package:
       name: 'Tabler Icons'
       url: 'https://github.com/tabler/tabler-icons'
     versions:
-      - v0.0.1
-      - v0.0.3
-      - v0.1.0
-      - v0.2.0
-      - v0.3.0
-      - v0.3.1
-      - v0.3.2
-      - v0.3.3
-      - v0.4.0
-      - v0.5.0
-      - v1.0.0
-      - v1.0.1
-      - v1.1.0
-      - v1.2.0
-      - v1.3.0
-      - v1.4.0
-      - v1.5.0
-      - v2.0.0
-      - v2.1.0
-      - v2.2.0
-      - v2.2.1
-      - v2.3.0
       - dev-main
-      - dev-l10-compatibility
+      - v3.4.0
+      - v3.3.0
+      - v3.2.0
+      - v3.1.0
+      - v3.0.5
+      - v3.0.4
+      - v3.0.3
+      - v3.0.0
+      - v2.48.0
+      - v2.47.0
+      - v2.46.0
+      - v2.45.0
+      - v2.44.0
+      - v2.43.0
+      - v2.42.0
+      - v2.41.0
+      - v2.40.0
+      - v2.39.0
+      - v2.38.0
+      - v2.37.0
+      - v2.36.0
+      - v2.35.0
+      - v2.34.0
+      - v2.33.0
+      - v2.32.0
+      - v2.31.0
+      - v2.30.0
+      - v2.29.0
+      - v2.28.0
+      - v2.27.0
+      - v2.26.0
+      - v2.25.0
+      - v2.24.0
+      - v2.23.0
+      - v2.22.0
+      - v2.21.0
+      - v2.20.0
+      - v2.19.0
+      - v2.18.0
+      - v2.17.0
+      - v2.16.0
+      - v2.15.0
+      - v2.14.0
+      - v2.13.0
+      - v2.12.0
+      - v2.11.0
+      - v2.10.1
+      - v2.10.0
+      - v2.9.2
+      - v2.9.1
+      - v2.9.0
+      - v2.8.0
+      - v2.7.0
+      - v2.6.0
+      - v2.5.0
+      - v2.4.1
+      - v2.4.0
+      - v2.3.0
+      - v2.2.1
+      - v2.2.0
+      - v2.1.2
+      - v1.119.0
+      - v1.118.0
+      - v1.117.0
+      - v1.115.0
+      - v1.113.0
+      - v1.111.0
+      - v1.101.0
+      - v1.100.0
+      - v1.97.0
+      - v1.96.1
+      - v1.96.0
   -
     package: codeat3/blade-teeny-icons
     name: 'Blade Teeny Icons'


### PR DESCRIPTION
Ryan doesn't seem to update his repo anymore. Some issues and pull requests to update to the newest icons are stale.
This one is more up to date. It has a weekly automatic GitHub action to update icons from the base repo.
I think this is better and more up to date choice.